### PR TITLE
PLF-8378: Fix Infinite Loading while exporting package

### DIFF
--- a/portlet/src/main/java/org/exoplatform/management/portlet/assets/js/controllers.js
+++ b/portlet/src/main/java/org/exoplatform/management/portlet/assets/js/controllers.js
@@ -418,6 +418,11 @@ define( "stagingControllers", [ "SHARED/jquery", "SHARED/juzu-ajax" ], function 
 	          scope.refreshController();
             });
           });
+          setTimeout(function() {
+              $scope.setResultMessage("", "info");
+              $scope.button_clicked = false;
+              $scope.refreshController();
+          },3000);
         } catch(exception) {
       	  $scope.button_clicked = false;
 	      $scope.refreshController();


### PR DESCRIPTION
The  "fileDownload" success callback in "controllers.js" is not called which prevents the hiding of the mask layer and the info message. 